### PR TITLE
「1-6 D2C ブランドの企画・生産・EC 販売を提供するサービスを作りたい」private endpoint の修正

### DIFF
--- a/1_web-application/1-6_integrated-platform-for-d2c-brand/azuredeploy.json
+++ b/1_web-application/1-6_integrated-platform-for-d2c-brand/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.10.61.36676",
-      "templateHash": "705928423806677872"
+      "templateHash": "8559407282168354294"
     }
   },
   "parameters": {
@@ -528,6 +528,25 @@
       ]
     },
     {
+      "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+      "apiVersion": "2022-01-01",
+      "name": "[format('{0}/{1}', format('private-endpoint-{0}-storage', parameters('workloadName')), 'default')]",
+      "properties": {
+        "privateDnsZoneConfigs": [
+          {
+            "name": "config1",
+            "properties": {
+              "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', format('privatelink.blob.{0}', environment().suffixes.storage))]"
+            }
+          }
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/privateDnsZones', format('privatelink.blob.{0}', environment().suffixes.storage))]",
+        "[resourceId('Microsoft.Network/privateEndpoints', format('private-endpoint-{0}-storage', parameters('workloadName')))]"
+      ]
+    },
+    {
       "type": "Microsoft.DocumentDB/databaseAccounts",
       "apiVersion": "2022-05-15",
       "name": "[format('cosmos-{0}', parameters('workloadName'))]",
@@ -583,6 +602,25 @@
       ]
     },
     {
+      "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+      "apiVersion": "2022-01-01",
+      "name": "[format('{0}/{1}', format('private-endpoint-{0}-cosmos', parameters('workloadName')), 'default')]",
+      "properties": {
+        "privateDnsZoneConfigs": [
+          {
+            "name": "config1",
+            "properties": {
+              "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.documents.azure.com')]"
+            }
+          }
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.documents.azure.com')]",
+        "[resourceId('Microsoft.Network/privateEndpoints', format('private-endpoint-{0}-cosmos', parameters('workloadName')))]"
+      ]
+    },
+    {
       "type": "Microsoft.DBforPostgreSQL/servers",
       "apiVersion": "2017-12-01",
       "name": "[format('psql-{0}', parameters('workloadName'))]",
@@ -623,6 +661,25 @@
       "dependsOn": [
         "[resourceId('Microsoft.DBforPostgreSQL/servers', format('psql-{0}', parameters('workloadName')))]",
         "[resourceId('Microsoft.Network/virtualNetworks/subnets', format('vnet-{0}', parameters('workloadName')), 'backend')]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+      "apiVersion": "2022-01-01",
+      "name": "[format('{0}/{1}', format('private-endpoint-{0}-psql', parameters('workloadName')), 'default')]",
+      "properties": {
+        "privateDnsZoneConfigs": [
+          {
+            "name": "config1",
+            "properties": {
+              "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.postgres.database.azure.com')]"
+            }
+          }
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.postgres.database.azure.com')]",
+        "[resourceId('Microsoft.Network/privateEndpoints', format('private-endpoint-{0}-psql', parameters('workloadName')))]"
       ]
     }
   ]

--- a/1_web-application/1-6_integrated-platform-for-d2c-brand/bicep/azuredeploy.bicep
+++ b/1_web-application/1-6_integrated-platform-for-d2c-brand/bicep/azuredeploy.bicep
@@ -344,6 +344,21 @@ resource privateEndpointBlobStorage 'Microsoft.Network/privateEndpoints@2022-01-
   }
 }
 
+resource privateDnsZoneGroupBlobStorage 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2022-01-01' = {
+  name: 'default'
+  parent: privateEndpointBlobStorage
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'config1'
+        properties: {
+          privateDnsZoneId: privateDnsZoneBlobStorage.id
+        }
+      }
+    ]
+  }
+}
+
 resource cosmosDb 'Microsoft.DocumentDB/databaseAccounts@2022-05-15' = {
   name: 'cosmos-${workloadName}'
   location: cosmosDbLocation
@@ -393,6 +408,21 @@ resource privateEndpointCosmosDb 'Microsoft.Network/privateEndpoints@2022-01-01'
   }
 }
 
+resource privateDnsZoneGroupCosmosDb 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2022-01-01' = {
+  name: 'default'
+  parent: privateEndpointCosmosDb
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'config1'
+        properties: {
+          privateDnsZoneId: privateDnsZoneCosmosDb.id
+        }
+      }
+    ]
+  }
+}
+
 resource postgreSql 'Microsoft.DBforPostgreSQL/servers@2017-12-01' = {
   name: 'psql-${workloadName}'
   location: resourceGroupLocation
@@ -427,5 +457,20 @@ resource privateEndpointPostgreSql 'Microsoft.Network/privateEndpoints@2022-01-0
     subnet: {
       id: virtualNetwork::subnetBackend.id
     }
+  }
+}
+
+resource privateDnsZoneGroupPostgreSql 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2022-01-01' = {
+  name: 'default'
+  parent: privateEndpointPostgreSql
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'config1'
+        properties: {
+          privateDnsZoneId: privateDnsZonePostgreSql.id
+        }
+      }
+    ]
   }
 }


### PR DESCRIPTION
「1-6 D2C ブランドの企画・生産・EC 販売を提供するサービスを作りたい」の構成において、下記のように仮想ネットワーク内のIPアドレス付与が行われない状態になっていたので修正します。

`workloadName` を `debug2` で作成したリソース群による確認結果
```
root@ad9db46fcbc5:/home# nslookup cosmos-debug2.documents.azure.com     
Server:         127.0.0.11
Address:        127.0.0.11#53

Non-authoritative answer:
cosmos-debug2.documents.azure.com       canonical name = cosmos-debug2.privatelink.documents.azure.com.
** server can't find cosmos-debug2.privatelink.documents.azure.com: NXDOMAIN

root@ad9db46fcbc5:/home# nslookup stdebug2.blob.core.windows.net 
Server:         127.0.0.11
Address:        127.0.0.11#53

Non-authoritative answer:
stdebug2.blob.core.windows.net  canonical name = stdebug2.privatelink.blob.core.windows.net.
** server can't find stdebug2.privatelink.blob.core.windows.net: NXDOMAIN

root@ad9db46fcbc5:/home# nslookup psql-debug2.postgres.database.azure.com
Server:         127.0.0.11
Address:        127.0.0.11#53

Non-authoritative answer:
psql-debug2.postgres.database.azure.com canonical name = psql-debug2.privatelink.postgres.database.azure.com.
** server can't find psql-debug2.privatelink.postgres.database.azure.com: NXDOMAIN
```

修正により下記のように内部IPアドレスが引けるようになりました。

`workloadName` を `debug0928` で作成したリソース群による確認結果
```
root@01b8582e7cab:/home# nslookup cosmos-debug0928.documents.azure.com
Server:         127.0.0.11
Address:        127.0.0.11#53

Non-authoritative answer:
cosmos-debug0928.documents.azure.com    canonical name = cosmos-debug0928.privatelink.documents.azure.com.
Name:   cosmos-debug0928.privatelink.documents.azure.com
Address: 10.0.2.6

root@01b8582e7cab:/home# nslookup psql-debug0928.postgres.database.azure.com
Server:         127.0.0.11
Address:        127.0.0.11#53

Non-authoritative answer:
psql-debug0928.postgres.database.azure.com      canonical name = psql-debug0928.privatelink.postgres.database.azure.com.
Name:   psql-debug0928.privatelink.postgres.database.azure.com
Address: 10.0.2.5

root@01b8582e7cab:/home# nslookup stdebug0928.blob.core.windows.net
Server:         127.0.0.11
Address:        127.0.0.11#53

Non-authoritative answer:
stdebug0928.blob.core.windows.net       canonical name = stdebug0928.privatelink.blob.core.windows.net.
Name:   stdebug0928.privatelink.blob.core.windows.net
Address: 10.0.2.4
```